### PR TITLE
Fix to shape based getter

### DIFF
--- a/download_dem.py
+++ b/download_dem.py
@@ -152,7 +152,7 @@ def _getGridsInBounds(latBounds,longBounds,dTheta = 1):
     '''
 
     #Get X-Y points at the specified spacing
-    lats = [math.floor(latBounds[0]) + i*dTheta for i in range(int(1 + (math.floor(latBounds[1]) - math.floor(latBounds[0]))/dTheta))]
+    lats = [math.ceil(latBounds[0]) + i*dTheta for i in range(int((math.ceil(latBounds[1]) - math.floor(latBounds[0]))/dTheta))]
     longs = [math.floor(longBounds[0]) + i*dTheta for i in range(int(1 + (math.floor(longBounds[1]) - math.floor(longBounds[0]))/dTheta))]
 
     #Iterate through points, creating a list of (lat,lon) tuples as we go


### PR DESCRIPTION
In creating the shape based getter I had incorrectly rounded the bounding coordinates of the shape to the defining coordinates of each grid (I was snapping to the lower left corner of a 1 degree grid instead of the upper left). This is now fixed.